### PR TITLE
Optimize CPU usage in overlay class and fix 0 div issue

### DIFF
--- a/src/main/java/com/rlweather/Drop.java
+++ b/src/main/java/com/rlweather/Drop.java
@@ -39,7 +39,12 @@ public class Drop {
         this.x2 = this.x1;
         this.y2 = this.y1;
 
-        this.x1 += this.wind + r.nextInt(this.div + this.div) - this.div; // -div to div
+        this.x1 += this.wind;
+        if (this.div > 0)
+        {
+            this.x1 += r.nextInt(this.div + this.div) - this.div; // -div to div
+        }
+
         this.y1 += this.gravity;
     }
 }


### PR DESCRIPTION
In the first commit, I removed the need to use a `BufferedImage` to draw the on screen graphics. You can use the object given as an argument to the `render()` method. This was most likely the culprit for the large CPU usage this plugin caused.

I also changed the way drops are cleared from the `LinkedList`, using `removeIf` instead. It's a little better, but this could probably be optimized further. However, the amount of drops in the list at any given time is *small enough* that this is unlikely to be of any major concern.

Second commit fixes #1 by adding an if check for `div > 0` before attempting to add the dither.