### PR TITLE
Possibly fixed sound playing on RL non-dev

### DIFF
--- a/src/main/java/com/rlweather/Sound.java
+++ b/src/main/java/com/rlweather/Sound.java
@@ -45,8 +45,7 @@ public class Sound {
         Clip clip = null; // yuck!
 
         try {
-            InputStream is = getClass().getResourceAsStream(soundFilePath);
-            AudioInputStream stream = AudioSystem.getAudioInputStream(is);
+            AudioInputStream stream = AudioSystem.getAudioInputStream(getClass().getResource(soundFilePath));
             clip = AudioSystem.getClip();
 
             // callback once sound is completed


### PR DESCRIPTION
This seems to have fixed playing sound, at least for me on Linux, since it no longer runs an unnecessary mark/reset test.

It's still worth switching from default audio playback provided by Java to an actual library that can handle more advanced features like setting volume level, etc but this might be a suitable fix for now.

This probably closes #6 